### PR TITLE
Fix crash when dye mod is not present

### DIFF
--- a/extender.lua
+++ b/extender.lua
@@ -19,7 +19,7 @@ for i, range in pairs(telemosaic.extender_ranges) do
 
 	local common_desc, basic_desc
 	if has_dye then
-		common_desc = S("Telemosaic Extender, Tier @1 (@2)")
+		common_desc = "Telemosaic Extender, Tier @1 (@2)"
 		basic_desc = S(common_desc, i, S("Grey"))
 	else
 		common_desc = "Telemosaic Extender, Tier @1"


### PR DESCRIPTION
Fixes a game crash when `dye` is not present. Sorry this was not tested properly before merging #19.

Credit to @Niklp09 for reporting - https://github.com/Archtec-io/archtec-mods/actions/runs/7786789043/job/21232396032#step:5:91