### PR TITLE
Add missing sounds to extender and beacon nodes

### DIFF
--- a/beacon.lua
+++ b/beacon.lua
@@ -19,6 +19,7 @@ for _,protected in pairs({true, false}) do
 		is_ground_content = false,
 		on_rightclick = telemosaic.rightclick,
 		digilines = telemosaic.digilines,
+		sounds = default.node_sound_metal_defaults(),
 	})
 
 	minetest.register_node("telemosaic:beacon"..node_name_suffix, {
@@ -34,6 +35,7 @@ for _,protected in pairs({true, false}) do
 		drop = "telemosaic:beacon_off"..node_name_suffix,
 		on_rightclick = telemosaic.rightclick,
 		digilines = telemosaic.digilines,
+		sounds = default.node_sound_metal_defaults(),
 	})
 
 	minetest.register_node("telemosaic:beacon_err"..node_name_suffix, {
@@ -49,6 +51,7 @@ for _,protected in pairs({true, false}) do
 		drop = "telemosaic:beacon_off"..node_name_suffix,
 		on_rightclick = telemosaic.rightclick,
 		digilines = telemosaic.digilines,
+		sounds = default.node_sound_metal_defaults(),
 	})
 
 	minetest.register_node("telemosaic:beacon_disabled"..node_name_suffix, {
@@ -64,6 +67,7 @@ for _,protected in pairs({true, false}) do
 		drop = "telemosaic:beacon_off"..node_name_suffix,
 		on_rightclick = telemosaic.rightclick,
 		digilines = telemosaic.digilines,
+		sounds = default.node_sound_metal_defaults(),
 	})
 end
 

--- a/extender.lua
+++ b/extender.lua
@@ -36,6 +36,7 @@ for i, range in pairs(telemosaic.extender_ranges) do
 		is_ground_content = false,
 		after_place_node = telemosaic.extender_place,
 		after_dig_node = telemosaic.extender_dig,
+		sounds = default.node_sound_metal_defaults(),
 	})
 
 	if has_dye then
@@ -59,6 +60,7 @@ for i, range in pairs(telemosaic.extender_ranges) do
 				is_ground_content = false,
 				after_place_node = telemosaic.extender_place,
 				after_dig_node = telemosaic.extender_dig,
+				sounds = default.node_sound_metal_defaults(),
 			})
 
 			minetest.register_craft({


### PR DESCRIPTION
Telemosaic extender and beacon nodes do not have any sounds which makes them eerily silent when players walk on them. I added metal sounds to the nodes in the Asuna fork of Telemosaic which seems like a fitting/thematic choice.